### PR TITLE
Fix superlogin.authenticate

### DIFF
--- a/src/ng-superlogin.js
+++ b/src/ng-superlogin.js
@@ -215,7 +215,7 @@ angular.module('superlogin', [])
         checkExpired: superloginSession.checkExpired,
         authenticate: function() {
           var deferred = $q.defer();
-          var session = superloginSession.getSession;
+          var session = superloginSession.getSession();
           if(session) {
             deferred.resolve(session);
           } else {


### PR DESCRIPTION
It was always returning the function instead of the `session` object, so the first `if` was always true.
