### PR TITLE
validateUsername()/validateEmail() now fail with $q.reject(err)

### DIFF
--- a/src/ng-superlogin.js
+++ b/src/ng-superlogin.js
@@ -419,7 +419,7 @@ angular.module('superlogin', [])
               if(err.status === 409) {
                 return $q.reject(false);
               }
-              return $q.reject(err.data);
+              return $q.reject(err);
             });
         },
         validateEmail: function(email) {
@@ -430,7 +430,7 @@ angular.module('superlogin', [])
               if(err.status === 409) {
                 return $q.reject(false);
               }
-              return $q.reject(err.data);
+              return $q.reject(err);
             });
         }
       };


### PR DESCRIPTION
validateUsername()/validateEmail() now return $q.reject(err) to allow a caller to test `err.status` when a reject occurs.

Once you've released this under a new version, can you then please update superlogin-demo with new version dependency?  Then I can add the other fix to `superlogin-demo` and commit/test it against the right version. No rush :) . 
